### PR TITLE
Add user-end console config

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -14,7 +14,7 @@ fn main() {
             // Not removing the LogPlugin will cause a panic!
             DefaultPlugins.build().disable::<LogPlugin>(),
             // Add the dev console plugin itself.
-            DevConsolePlugin,
+            DevConsolePlugin::default(),
         ))
         .add_systems(Startup, test)
         .run();

--- a/examples/custom_functions.rs
+++ b/examples/custom_functions.rs
@@ -84,7 +84,7 @@ fn main() {
         .add_plugins((
             ConsoleLogPlugin::default().append_filter(module_path!(), Level::TRACE),
             DefaultPlugins.build().disable::<LogPlugin>(),
-            DevConsolePlugin,
+            DevConsolePlugin::default(),
         ))
         .run();
 }

--- a/examples/resource.rs
+++ b/examples/resource.rs
@@ -51,7 +51,7 @@ fn main() {
         .add_plugins((
             ConsoleLogPlugin::default(),
             DefaultPlugins.build().disable::<LogPlugin>(),
-            DevConsolePlugin,
+            DevConsolePlugin::default(),
         ))
         .run();
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use bevy_egui::egui::{Color32, FontId, TextFormat};
 
 /// The configuration of the developer console.
-#[derive(Resource)]
+#[derive(Resource, Clone)]
 pub struct ConsoleConfig {
     /// The colors used in the developer console.
     pub theme: ConsoleTheme,
@@ -23,6 +23,7 @@ impl Default for ConsoleConfig {
 }
 
 /// The colors used by the text in the developer console.
+#[derive(Clone)]
 pub struct ConsoleTheme {
     /// The font used in the developer console.
     pub font: FontId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@ pub mod ui;
 /// Adds a Developer Console to your Bevy application.
 ///
 /// Requires [ConsoleLogPlugin](logging::log_plugin::ConsoleLogPlugin).
-pub struct DevConsolePlugin;
+pub struct DevConsolePlugin {
+    /// Modify the theme and 'open console' key here
+    pub console_config: ConsoleConfig,
+}
 impl Plugin for DevConsolePlugin {
     fn build(&self, app: &mut App) {
         if !app.is_plugin_added::<EguiPlugin>() {
@@ -32,7 +35,7 @@ impl Plugin for DevConsolePlugin {
 
         app.init_resource::<ConsoleUiState>()
             .init_resource::<CommandHints>()
-            .init_resource::<ConsoleConfig>()
+            .insert_resource(self.console_config.clone())
             .add_systems(
                 Update,
                 (
@@ -41,5 +44,13 @@ impl Plugin for DevConsolePlugin {
                     ui::render_ui.run_if(|s: Res<ConsoleUiState>| s.open),
                 ),
             );
+    }
+}
+
+impl Default for DevConsolePlugin {
+    fn default() -> Self {
+        Self {
+            console_config: ConsoleConfig::default(),
+        }
     }
 }


### PR DESCRIPTION
# Objective

Let the user change the theme & 'open console' key.

Having a modifiable key is especially important, as the KeyCode::Grave simply isn't useable on my Swedish keyboard.

## Solution

Add ``ConsoleConfig`` as a param to ``DevConsolePlugin``

---

I don't have any real experience with how things should be written in this aspect, so let me know if anything ought to be done differently.
