### PR TITLE
Improve tests and add AST assertions with nightly features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'

--- a/src/builtin_parser/parser.rs
+++ b/src/builtin_parser/parser.rs
@@ -675,19 +675,95 @@ fn parse_object(
 
 #[cfg(test)]
 mod tests {
+    use logos::Span;
+
+    use crate::builtin_parser::Spanned;
+
     use super::super::lexer::TokenStream;
     use super::super::Environment;
-    use super::parse;
+    use super::{parse, Expression};
 
     #[test]
     fn var_assign() {
         let mut lexer = TokenStream::new("x = 1 + 2 - 30 + y");
         let environment = Environment::default();
 
-        let ast = parse(&mut lexer, &environment);
+        let ast = parse(&mut lexer, &environment).unwrap();
 
-        assert!(ast.is_ok());
+        let mut stmts = ast.into_iter();
 
-        // TODO: figure out how to assert ast
+        use crate::builtin_parser::parser::Operator::*;
+        use crate::builtin_parser::Number::*;
+        use Expression::*;
+
+        assert!(matches!(
+            stmts.next(),
+            Some(Spanned {
+                span: Span { start: 0, end: 18 },
+                value:
+                    VarAssign {
+                        name:
+                            box Spanned {
+                                span: Span { start: 0, end: 1 },
+                                value: Variable(_),
+                            },
+                        value:
+                            box Spanned {
+                                span: Span { start: 4, end: 18 },
+                                value:
+                                    BinaryOp {
+                                        left:
+                                            box Spanned {
+                                                span: Span { start: 4, end: 14 },
+                                                value:
+                                                    BinaryOp {
+                                                        left:
+                                                            box Spanned {
+                                                                span: Span { start: 4, end: 9 },
+                                                                value:
+                                                                    BinaryOp {
+                                                                        left:
+                                                                            box Spanned {
+                                                                                span:
+                                                                                    Span {
+                                                                                        start: 4,
+                                                                                        end: 5,
+                                                                                    },
+                                                                                value:
+                                                                                    Number(Integer(1)),
+                                                                            },
+                                                                        operator: Add,
+                                                                        right:
+                                                                            box Spanned {
+                                                                                span:
+                                                                                    Span {
+                                                                                        start: 8,
+                                                                                        end: 9,
+                                                                                    },
+                                                                                value:
+                                                                                    Number(Integer(2)),
+                                                                            },
+                                                                    },
+                                                            },
+                                                        operator: Sub,
+                                                        right:
+                                                            box Spanned {
+                                                                span: Span { start: 12, end: 14 },
+                                                                value: Number(Integer(30)),
+                                                            },
+                                                    },
+                                            },
+                                        operator: Add,
+                                        right:
+                                            box Spanned {
+                                                span: Span { start: 17, end: 18 },
+                                                value: Variable(_),
+                                            },
+                                    },
+                            },
+                    },
+            })
+        ));
+        // println!("{:#?}", stmts.next());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(test, feature(box_patterns))]
 
 use bevy::prelude::*;
 use bevy_egui::EguiPlugin;


### PR DESCRIPTION
# Objective

There isn't an easy way to assert the AST in unit tests.

## Solution

Use the nightly `box_pattern` feature in tests (This doesn't make the library itself nightly, only the tests)