### PR TITLE
Update to Bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,18 @@ builtin-parser = ["dep:logos"]
 
 [dependencies]
 # This crate by itself doesn't use any bevy features, but `bevy_egui` (dep) uses "bevy_asset".
-bevy = { version = "0.12.1", default-features = false, features = [] }
-bevy_egui = "0.24.0"
+bevy = { version = "0.13.0", default-features = false, features = [] }
+bevy_egui = "0.25.0"
 chrono = "0.4.31"
 tracing-log = "0.2.0"
 tracing-subscriber = "0.3.18"
 web-time = "1.0.0"
 
 # builtin-parser features
-logos = { version = "0.13.0", optional = true }
+logos = { version = "0.14.0", optional = true }
 
 [dev-dependencies]
-bevy = "0.12.1"
+bevy = "0.13.0"
 
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Image of the developer console](doc/console.png)
 
 > [!WARNING]  
+>
 > `bevy_dev_console` is currently in its early development stages. Expect breaking changes in the near future (especially when using the built-in command parser). For this reason its only available as a git package at the moment.
 
 ## Features
@@ -67,4 +68,4 @@
 
 | bevy   | bevy_dev_console |
 | ------ | ---------------- |
-| 0.12.* | git (master)     |
+| 0.13.* | git (master)     |

--- a/examples/custom_functions.rs
+++ b/examples/custom_functions.rs
@@ -5,13 +5,14 @@ use bevy::prelude::*;
 use bevy_dev_console::builtin_parser::{Environment, EvalError, Number, Spanned, StrongRef, Value};
 use bevy_dev_console::prelude::*;
 use bevy_dev_console::register;
+use web_time as time;
 
 // Declare the functions we want to create:
 
 /// Basic function
 fn time_since_epoch() {
-    let time = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
+    let time = time::SystemTime::now()
+        .duration_since(time::UNIX_EPOCH)
         .unwrap();
     info!("The unix epoch was {} seconds ago", time.as_secs());
 }

--- a/src/builtin_parser.rs
+++ b/src/builtin_parser.rs
@@ -80,6 +80,7 @@ impl CommandParser for BuiltinCommandParser {
         let ast = parser::parse(&mut tokens, environment);
 
         dbg!(&ast);
+        
         match ast {
             Ok(ast) => match runner::run(ast, world) {
                 Ok(()) => (),

--- a/src/builtin_parser.rs
+++ b/src/builtin_parser.rs
@@ -80,7 +80,7 @@ impl CommandParser for BuiltinCommandParser {
         let ast = parser::parse(&mut tokens, environment);
 
         dbg!(&ast);
-        
+
         match ast {
             Ok(ast) => match runner::run(ast, world) {
                 Ok(()) => (),

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ impl Default for ConsoleConfig {
     fn default() -> Self {
         Self {
             theme: ConsoleTheme::ONE_DARK,
-            open_key: KeyCode::Grave,
+            open_key: KeyCode::Backquote,
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -49,7 +49,7 @@ pub(crate) fn read_logs(mut logs: EventReader<LogMessage>, mut state: ResMut<Con
 
 pub(crate) fn open_close_ui(
     mut state: ResMut<ConsoleUiState>,
-    key: Res<Input<KeyCode>>,
+    key: Res<ButtonInput<KeyCode>>,
     config: Res<ConsoleConfig>,
 ) {
     if key.just_pressed(config.open_key) {
@@ -61,7 +61,7 @@ pub(crate) fn render_ui(
     mut contexts: EguiContexts,
     mut commands: Commands,
     mut state: ResMut<ConsoleUiState>,
-    key: Res<Input<KeyCode>>,
+    key: Res<ButtonInput<KeyCode>>,
     mut hints: ResMut<CommandHints>,
     config: Res<ConsoleConfig>,
 ) {
@@ -74,7 +74,7 @@ pub(crate) fn render_ui(
         }
     };
 
-    if key.just_pressed(KeyCode::Return) {
+    if key.just_pressed(KeyCode::Enter) {
         submit_command(&mut state.command);
     }
 


### PR DESCRIPTION
# Objective

Update to Bevy 0.13

Fixes #1.
Unblocks #3.

## Solution

Update `bevy` to `0.13`, `bevy_egui` to `0.25`, and `logos` to `0.14`.

Also fixed some bugs.