### PR TITLE
Add more parser errors

### DIFF
--- a/src/builtin_parser/lexer.rs
+++ b/src/builtin_parser/lexer.rs
@@ -41,8 +41,12 @@ pub enum Token {
     #[token("&")]
     Ampersand,
 
+    #[token("loop")]
+    Loop,
     #[token("for")]
     For,
+    #[token("while")]
+    While,
 
     #[token("in")]
     In,


### PR DESCRIPTION
# Objective

Work towards resolving https://github.com/doonv/bevy_dev_console/issues/4.

## Solution

Add more parser errors.

I removed parsing for `for` loops because they didn't do anything.
