### PR TITLE
Update `bevy_egui` to `0.26.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ builtin-parser = ["dep:logos"]
 [dependencies]
 # This crate by itself doesn't use any bevy features, but `bevy_egui` (dep) uses "bevy_asset".
 bevy = { version = "0.13.0", default-features = false, features = [] }
-bevy_egui = "0.25.0"
+bevy_egui = "0.26.0"
 chrono = "0.4.31"
 tracing-log = "0.2.0"
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
# Objective

Keep dependencies up to date

## Solution

Update `bevy_egui` to version `0.26.0`

---

## Changelog

- Updated `bevy_egui` to `0.26.0`
