### PR TITLE
Add autocompletions for functions and variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,15 @@ license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["builtin-parser"]
+default = ["builtin-parser", "completions", "builtin-parser-completions"]
+
+completions = []
+
+builtin-parser-completions = [
+    "completions",
+    "builtin-parser",
+    "dep:fuzzy-matcher",
+]
 
 builtin-parser = ["dep:logos"]
 
@@ -24,6 +32,7 @@ web-time = "1.0.0"
 
 # builtin-parser features
 logos = { version = "0.14.0", optional = true }
+fuzzy-matcher = { version = "0.3.7", optional = true }
 
 [dev-dependencies]
 bevy = "0.13.0"

--- a/src/builtin_parser/completions.rs
+++ b/src/builtin_parser/completions.rs
@@ -1,0 +1,55 @@
+use bevy::prelude::*;
+
+use super::runner::environment::Variable;
+use super::Environment;
+
+/// Stores the names of variables and functions for fast async access.
+#[derive(Resource)]
+pub struct EnvironmentCache {
+    pub function_names: Vec<String>,
+    pub variable_names: Vec<String>,
+}
+impl FromWorld for EnvironmentCache {
+    fn from_world(world: &mut World) -> Self {
+        if let Some(environment) = world.get_non_send_resource::<Environment>() {
+            store_in_cache(environment)
+        } else {
+            Self::empty()
+        }
+    }
+}
+impl EnvironmentCache {
+    pub const fn empty() -> Self {
+        EnvironmentCache {
+            function_names: Vec::new(),
+            variable_names: Vec::new(),
+        }
+    }
+}
+
+pub fn store_in_cache(environment: &Environment) -> EnvironmentCache {
+    let mut function_names = Vec::new();
+    let mut variable_names = Vec::new();
+    store_in_cache_vec(environment, &mut function_names, &mut variable_names);
+
+    EnvironmentCache {
+        function_names,
+        variable_names,
+    }
+}
+fn store_in_cache_vec(
+    environment: &Environment,
+    function_names: &mut Vec<String>,
+    variable_names: &mut Vec<String>,
+) {
+    for (name, variable) in &environment.variables {
+        match variable {
+            Variable::Function(_) => function_names.push(name.clone()),
+            Variable::Unmoved(_) => variable_names.push(name.clone()),
+            Variable::Moved => {}
+        }
+    }
+    if let Some(environment) = &environment.parent {
+        store_in_cache_vec(environment, function_names, variable_names);
+    }
+}

--- a/src/builtin_parser/runner/environment.rs
+++ b/src/builtin_parser/runner/environment.rs
@@ -3,12 +3,11 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 
+use crate::builtin_parser::SpanExtension;
 use bevy::ecs::world::World;
 use bevy::log::warn;
 use bevy::reflect::TypeRegistration;
 use logos::Span;
-
-use crate::builtin_parser::SpanExtension;
 
 use super::super::parser::Expression;
 use super::super::Spanned;
@@ -203,12 +202,10 @@ pub enum Variable {
 }
 
 /// The environment stores all variables and functions.
-#[derive(Debug)]
 pub struct Environment {
-    parent: Option<Box<Environment>>,
-    variables: HashMap<String, Variable>,
+    pub(crate) parent: Option<Box<Environment>>,
+    pub(crate) variables: HashMap<String, Variable>,
 }
-
 impl Default for Environment {
     fn default() -> Self {
         let mut env = Self {
@@ -352,6 +349,7 @@ impl Environment {
         let name = name.into();
         if self.variables.contains_key(&name) {
             warn!("Function {name} declared twice.");
+        } else {
         }
         self.variables
             .insert(name, Variable::Function(function.into_function()));

--- a/src/builtin_parser/runner/environment.rs
+++ b/src/builtin_parser/runner/environment.rs
@@ -349,7 +349,6 @@ impl Environment {
         let name = name.into();
         if self.variables.contains_key(&name) {
             warn!("Function {name} declared twice.");
-        } else {
         }
         self.variables
             .insert(name, Variable::Function(function.into_function()));

--- a/src/config.rs
+++ b/src/config.rs
@@ -135,6 +135,16 @@ impl ConsoleTheme {
         }
     }
 
+    /// Returns a [`TextFormat`] with the default font and white color.
+    pub fn format_bold(&self) -> TextFormat {
+        TextFormat {
+            font_id: self.font.clone(),
+            color: Color32::WHITE,
+
+            ..default()
+        }
+    }
+
     define_text_format_method!(format_dark, dark);
     define_text_format_method!(format_error, error);
     define_text_format_method!(format_warning, warning);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,11 @@ impl Plugin for DevConsolePlugin {
         {
             app.init_non_send_resource::<builtin_parser::Environment>();
             app.init_resource::<command::DefaultCommandParser>();
+            #[cfg(feature = "builtin-parser-completions")]
+            app.init_resource::<builtin_parser::completions::EnvironmentCache>();
         }
+        #[cfg(feature = "completions")]
+        app.init_resource::<command::AutoCompletions>();
 
         app.init_resource::<ConsoleUiState>()
             .init_resource::<CommandHints>()

--- a/src/logging/log_plugin.rs
+++ b/src/logging/log_plugin.rs
@@ -29,6 +29,7 @@ use bevy::utils::tracing::Subscriber;
 pub use bevy::utils::tracing::{warn, Level};
 
 use bevy::app::{App, Plugin, Update};
+use bevy::utils::tracing;
 use tracing_log::LogTracer;
 use tracing_subscriber::field::Visit;
 #[cfg(feature = "tracing-chrome")]

--- a/src/ui/completions.rs
+++ b/src/ui/completions.rs
@@ -28,7 +28,7 @@ pub fn completions(
         }
 
         let cursor_index = (|| {
-            // Conver the cursor's char index into a byte index
+            // Convert the cursor's char index into a byte index
             // aswell as returning the character at the cursor's position position
             let (primary_index, char) = state
                 .command

--- a/src/ui/completions.rs
+++ b/src/ui/completions.rs
@@ -1,0 +1,152 @@
+use bevy::ecs::system::Commands;
+use bevy_egui::egui;
+
+use crate::command::{AutoCompletions, CompletionSuggestion, UpdateAutoComplete};
+use crate::prelude::ConsoleConfig;
+
+use super::ConsoleUiState;
+
+/// The max amount of completion suggestions shown at once.
+pub const MAX_COMPLETION_SUGGESTIONS: usize = 6;
+
+pub fn completions(
+    text_edit: egui::text_edit::TextEditOutput,
+    text_edit_id: egui::Id,
+    state: &mut ConsoleUiState,
+    ui: &mut egui::Ui,
+    mut commands: Commands,
+    completions: &AutoCompletions,
+    config: &ConsoleConfig,
+) {
+    let text_edit_complete_id = ui.make_persistent_id("text_edit_complete");
+
+    if let Some(cursor_range) = text_edit.state.cursor.char_range() {
+        let [primary, secondary] = cursor_range.sorted();
+
+        fn non_keyword(character: char) -> bool {
+            !(character.is_alphanumeric() || character == '_')
+        }
+
+        let cursor_index = (|| {
+            // Conver the cursor's char index into a byte index
+            // aswell as returning the character at the cursor's position position
+            let (primary_index, char) = state
+                .command
+                .char_indices()
+                .nth(primary.index.saturating_sub(1))?;
+
+            if non_keyword(char) {
+                return None;
+            }
+
+            Some(primary_index)
+        })();
+        if text_edit.response.changed() {
+            state.selected_completion = 0;
+        }
+        // todo check cursor position changed https://github.com/emilk/egui/discussions/4540
+        // if text_edit.response.changed() {
+        if true {
+            if let Some(cursor_index) = cursor_index {
+                ui.memory_mut(|mem| {
+                    if !completions.is_empty() {
+                        mem.open_popup(text_edit_complete_id)
+                    }
+                });
+                let before_cursor = &state.command[..=cursor_index];
+                let keyword_before = match before_cursor.rfind(non_keyword) {
+                    // If found, return the slice from the end of the non-alphanumeric character to the cursor position
+                    Some(index) => &before_cursor[(index + 1)..],
+                    // If not found, the whole substring is a word
+                    None => before_cursor,
+                };
+                commands.add(UpdateAutoComplete(keyword_before.to_owned()));
+            } else {
+                ui.memory_mut(|mem| {
+                    if mem.is_popup_open(text_edit_complete_id) {
+                        mem.close_popup();
+                    }
+                });
+            }
+        }
+        if let Some(cursor_index) = cursor_index {
+            if ui.input(|i| i.key_pressed(egui::Key::Tab)) {
+                // Remove the old text
+                let before_cursor = &state.command[..=cursor_index];
+                let index_before = match before_cursor.rfind(non_keyword) {
+                    Some(index) => index + 1,
+                    None => 0,
+                };
+                let after_cursor = &state.command[cursor_index..];
+                match after_cursor.find(non_keyword) {
+                    Some(characters_after) => state
+                        .command
+                        .drain(index_before..cursor_index + characters_after),
+                    None => state.command.drain(index_before..),
+                };
+                // Add the completed text
+                let completed_text = &completions.0[state.selected_completion].suggestion;
+
+                state.command.insert_str(index_before, completed_text);
+
+                // Set the cursor position
+                let mut text_edit_state = text_edit.state;
+                let mut cursor_range = egui::text::CCursorRange::two(primary, secondary);
+
+                cursor_range.primary.index +=
+                    completed_text.len() - (cursor_index - index_before) - 1;
+                cursor_range.secondary.index +=
+                    completed_text.len() - (cursor_index - index_before) - 1;
+
+                text_edit_state.cursor.set_char_range(Some(cursor_range));
+                egui::TextEdit::store_state(ui.ctx(), text_edit_id, text_edit_state);
+            }
+        }
+    }
+    egui::popup_below_widget(ui, text_edit_complete_id, &text_edit.response, |ui| {
+        ui.vertical(|ui| {
+            for (
+                i,
+                CompletionSuggestion {
+                    suggestion,
+                    highlighted_indices,
+                },
+            ) in completions.iter().take(6).enumerate()
+            {
+                let mut layout = egui::text::LayoutJob::default();
+                for (i, _) in suggestion.char_indices() {
+                    layout.append(
+                        &suggestion[i..=i],
+                        0.0,
+                        if highlighted_indices.contains(&i) {
+                            config.theme.format_bold()
+                        } else {
+                            config.theme.format_text()
+                        },
+                    );
+                }
+                let res = ui.label(layout);
+                if i == state.selected_completion {
+                    res.highlight();
+                }
+            }
+        })
+    });
+}
+
+/// Also consumes the up and down arrow keys.
+pub fn change_selected_completion(
+    ui: &mut egui::Ui,
+    state: &mut ConsoleUiState,
+    completions: &[CompletionSuggestion],
+) {
+    if ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)) {
+        state.selected_completion = state.selected_completion.saturating_sub(1);
+    }
+    if ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)) {
+        state.selected_completion = state
+            .selected_completion
+            .saturating_add(1)
+            .min(completions.len() - 1);
+    }
+}


### PR DESCRIPTION
# Objective

Fixes #26 

## Solution

There's a new command (`UpdateAutoComplete`) that the UI calls when the command is changed or when the cursor moves (currently does it every frame). Then the `UpdateAutoComplete` command calls `CommandParser::completion` which then makes the current command parser return a list of `CompletionSuggestion`s, which is then displayed to user.

---

## Changelog

- Added autocompletions
  - The `CommandParser` trait has a new optional method: `completion`, every time the UI calls this method every time the command changes or the cursor changes.
  - The Builtin-parser now implements the new optional `CommandParser` method.
  - Added `CompletionSuggestion`, which represents a completion suggestion.
  - ...other stuff i probably forgot about
