### PR TITLE
chore(deps): update `bevy_egui` to 0.30.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ builtin-parser = ["dep:logos"]
 [dependencies]
 # This crate by itself doesn't use any bevy features, but `bevy_egui` (dep) uses "bevy_asset".
 bevy = { version = "0.14.0", default-features = false, features = [] }
-bevy_egui = "0.28.0"
+bevy_egui = "0.30.0"
 chrono = "0.4.31"
 tracing-log = "0.2.0"
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
# Objective

Improve compatibility with the latest `bevy_egui` version.

## Solution

Updated `bevy_egui` dependency in Cargo.toml, tested in local project, and ran `cargo test` to confirm all tests still pass.

## Changelog

- Updated `bevy_egui` version from 0.28.0 to 0.30.0